### PR TITLE
fix: use the main prop for the application entry point.

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -32,7 +32,7 @@ const http = require('http');
  * Get port from environment and store in Express.
  */
 
-const port = normalizePort(process.env.PORT || '3000');
+const port = normalizePort(process.env.PORT || '8080');
 app.set('port', port);
 
 /**

--- a/bin/www
+++ b/bin/www
@@ -25,7 +25,7 @@
  */
 
 const app = require('../app');
-const debug = require('debug')('nodejs-rest-http:server');
+const debug = require('debug')('nodejs-health-check-redhat:server');
 const http = require('http');
 
 /**

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
     "release": "standard-version -a",
     "openshift": "nodeshift --strictSSL=false --dockerImage=registry.access.redhat.com/rhoar-nodejs/nodejs-8",
     "postinstall": "license-reporter report -s && license-reporter save -s --xml licenses.xml",
-    "start": "PORT=8080 node ./bin/www"
+    "start": "node ."
   },
+  "main": "./bin/www",
   "standard-version": {
     "scripts": {
       "postbump": "npm run postinstall && node release.js",


### PR DESCRIPTION
npm start will now look at the main property for the entry point.  Port 8080 is now set as the default port instead of 3000.   This is a fix related to bucharest-gold/centos7-s2i-nodejs#33\#issuecomment-382587104.

fixes #28